### PR TITLE
Pull request to make ELK clustered

### DIFF
--- a/elk-stack.yaml
+++ b/elk-stack.yaml
@@ -245,7 +245,7 @@ resources:
             - coms
             - public_key
         state_repos: |
-          https://github.com/dani4571/elk-formula.git
+          https://github.com/rcbops/elk-formula.git
         kibana_passwd:
           - get_param: kibana-passwd
         kibana_user:

--- a/env.yaml
+++ b/env.yaml
@@ -1,2 +1,2 @@
 resource_registry:
-  Salt::Minion: https://raw.githubusercontent.com/dani4571/RPC-Heat-ELK/master/minion_stack.yaml
+  Salt::Minion: https://raw.githubusercontent.com/rcbops/RPC-Heat-ELK/master/minion_stack.yaml


### PR DESCRIPTION
Currently deploys a configurable number of ELK nodes (elasticsearch clustered) along with an HAProxy to load balance logstash on 5544, kibana on 80 and elasticsearch on ports 9200/9300
